### PR TITLE
Adding cs client name variable to the config chart for the installation

### DIFF
--- a/charts/config/templates/config.yaml
+++ b/charts/config/templates/config.yaml
@@ -6,4 +6,5 @@ metadata:
 data:  
   # host name of the Commserve or gateway
   CV_CSHOSTNAME: {{ tpl .Values.csOrGatewayHostName . }}
+  CV_CSCLIENTNAME: {{ tpl .Values.csClientName . }}
 


### PR DESCRIPTION
This variable is set so that installation using pseudo clients and FwConfig route gets generated