### PR TITLE
feat: add toggle for secret creation

### DIFF
--- a/charts/config/templates/secret.yaml
+++ b/charts/config/templates/secret.yaml
@@ -1,10 +1,11 @@
+{{- if ne (default false (.Values.secret).notCreate) true }}
 apiVersion: v1
 kind: Secret
-metadata:  
+metadata:
   name: {{ include "cv.metadataname2" (list . "cvcreds") }}
   namespace: {{ include "cv.namespace" . }}
 data:
-  # This section contains the credentials to connect to the Commserver. 
+  # This section contains the credentials to connect to the Commserver.
   # User names and password should be base-64 encoded.
 {{- if (.Values.secret).user }}
   CV_COMMCELL_USER: {{ or (.Values.secret).user "" | b64enc }}
@@ -21,13 +22,13 @@ data:
 {{- if (.Values.secret).CCCertificatePassword }}
   CCCertificatePassword: {{ or (.Values.secret).CCCertificatePassword "" | b64enc}}
 {{- end }}
-
+{{- end }}
 ---
 
 {{if (.Values.pullsecret).create }}
 apiVersion: v1
 kind: Secret
-metadata:  
+metadata:
   name: {{ include "cv.metadataname2" (list . .Values.pullsecret.name) }}
   namespace: {{ include "cv.namespace" . }}
 type: kubernetes.io/dockerconfigjson

--- a/charts/config/values.yaml
+++ b/charts/config/values.yaml
@@ -2,6 +2,7 @@
 # csClientName:         # Optional. client name of the Commserve
 # secret:               # username/password or authcode used for registering the commvault components with the commserve
                         # when installing the commserve component the user and password is required for first user
+  # notCreate:          # Optional. Set to true if secret should not be created as part of config creation
   # user:               # Optional. Plain text user name used for install.
   # password:           # Optional. Plain text password.
   # authcode:           # Optional. Authcode can be given in place of username/password


### PR DESCRIPTION
This PR adds a option to disable the creation of a secret in the config helm chart. This is useful when you want to deploy the secret with GitOps tooling, like for example external secrets operator, sealed secrets, etc. 