### PR TITLE
Implement layout versioning for certificate path persistence (SP 42 CU105+)

### DIFF
--- a/charts/accessnode/Chart.yaml
+++ b/charts/accessnode/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: accessnode
 description: A Helm chart for creating an access node
 type: application
-version: "1.0.9"
+version: "1.0.10"
 appVersion: "1"

--- a/charts/accessnode/templates/_pvc.tpl
+++ b/charts/accessnode/templates/_pvc.tpl
@@ -170,7 +170,7 @@ storageClass:
           subPath: Registry
         {{- end }}
         - name: cv-storage-certsandlogs
-          mountPath: /opt/{{include "cv.utils.getOemPath" .}}/appdata
+          mountPath: {{include "cv.paths.certMountPath" .}}
           subPath: certificates
         {{- if eq (include "cv.useInitContainer" .) "true" }}
         - name: cv-storage-certsandlogs

--- a/charts/accessnode/templates/_utils.tpl
+++ b/charts/accessnode/templates/_utils.tpl
@@ -233,3 +233,94 @@ Returns either commvault or metallic depending on the oem id
 {{- "commvault" }}
 {{- end }}
 {{- end }}
+
+{{/*
+Returns the CU/build number (3rd number) from the tag. e.g. 105 from 11.42.105.Rev1425
+Returns 0 if fewer than 3 numbers exist in the tag.
+*/}}
+{{- define "cv.utils.getCUPack" }}
+{{- $tag := include "cv.utils.getTag" . }}
+{{- $numbers := regexFindAll "(\\d+)" $tag 3 }}
+{{- if ge (len $numbers) 3 }}
+{{- atoi (index $numbers 2) }}
+{{- else }}
+{{- 0 }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns "true" if the image tag version is at least major.fr.cu
+Supports both 2-param (version, FR) and 3-param (version, FR, CU) checks.
+Usage:
+  {{- if eq (include "cv.utils.isMinVersion3" (list . 11 42 105)) "true" }}
+*/}}
+{{- define "cv.utils.isMinVersion3" }}
+{{- $root := index . 0 }}
+{{- $version := index . 1 }}
+{{- $fr := index . 2 }}
+{{- $cu := index . 3 }}
+{{- $curVer := atoi (include "cv.utils.getVersion" $root) }}
+{{- $curFR := atoi (include "cv.utils.getFeatureRelease" $root) }}
+{{- $curCU := atoi (include "cv.utils.getCUPack" $root) }}
+{{- if gt $curVer $version }}
+{{- printf "true" }}
+{{- else if lt $curVer $version }}
+{{- printf "false" }}
+{{- else if gt $curFR $fr }}
+{{- printf "true" }}
+{{- else if lt $curFR $fr }}
+{{- printf "false" }}
+{{- else if ge $curCU $cu }}
+{{- printf "true" }}
+{{- else }}
+{{- printf "false" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Determines the installation layout version (v1 or v2).
+Priority:
+  1. Explicit Helm value: global.installLayoutVersion
+  2. Existing deployment annotation: commvault.com/install-layout
+  3. Fresh install version inference (>= 11.42.105 → v2)
+  4. Fallback to v1
+*/}}
+{{- define "cv.installLayoutVersion" }}
+{{- if ((.Values.global).installLayoutVersion) }}
+{{- .Values.global.installLayoutVersion | trim }}
+{{- else }}
+{{- $objectname := include "cv.metadataname" . }}
+{{- $namespace := include "cv.namespace" . }}
+{{- $statefulset := or .Values.statefulset ((.Values).global).statefulset }}
+{{- $kind := "Deployment" }}
+{{- if $statefulset }}
+{{- $kind = "StatefulSet" }}
+{{- end }}
+{{- $existing := lookup "apps/v1" $kind $namespace $objectname }}
+{{- if and $existing $existing.metadata $existing.metadata.annotations (index $existing.metadata.annotations "commvault.com/install-layout") }}
+{{- index $existing.metadata.annotations "commvault.com/install-layout" | trim }}
+{{- else if not $existing }}
+{{- if eq (include "cv.utils.isMinVersion3" (list . 11 42 105)) "true" }}
+{{- printf "v2" }}
+{{- else }}
+{{- printf "v1" }}
+{{- end }}
+{{- else }}
+{{- printf "v1" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns the appdata certificate mount path based on layout version.
+v1: /opt/commvault/appdata (old path - PVC mounts here, certificates/ is a subdir inside)
+v2: /var/opt/commvault/Instance001/appdata/certificates (new path - PVC mounts directly at certificates dir)
+*/}}
+{{- define "cv.paths.certMountPath" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/appdata/certificates" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/%s/appdata" (include "cv.utils.getOemPath" .) }}
+{{- end }}
+{{- end }}

--- a/charts/accessnode/templates/_utils.tpl
+++ b/charts/accessnode/templates/_utils.tpl
@@ -324,3 +324,59 @@ v2: /var/opt/commvault/Instance001/appdata/certificates (new path - PVC mounts d
 {{- printf "/opt/%s/appdata" (include "cv.utils.getOemPath" .) }}
 {{- end }}
 {{- end }}
+
+{{/*
+Returns the appdata base path based on layout version.
+v1: /opt/commvault/appdata
+v2: /var/opt/commvault/Instance001/appdata
+*/}}
+{{- define "cv.paths.appdata" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/appdata" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/%s/appdata" (include "cv.utils.getOemPath" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns the jobResults path based on layout version.
+v1: /opt/commvault/iDataAgent/jobResults
+v2: /var/opt/commvault/Instance001/data/commvaultdata/jobResults
+*/}}
+{{- define "cv.paths.jobResults" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/data/commvaultdata/jobResults" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/%s/iDataAgent/jobResults" (include "cv.utils.getOemPath" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns the IndexCache path based on layout version.
+v1: /opt/commvault/MediaAgent/IndexCache
+v2: /var/opt/commvault/Instance001/data/commvaultdata/IndexCache
+*/}}
+{{- define "cv.paths.indexCache" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/data/commvaultdata/IndexCache" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/%s/MediaAgent/IndexCache" (include "cv.utils.getOemPath" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns the DDB path based on layout version.
+v1: /opt/ddb
+v2: /var/opt/commvault/Instance001/data/commvaultdata/DDB
+*/}}
+{{- define "cv.paths.ddb" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/data/commvaultdata/DDB" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/ddb" }}
+{{- end }}
+{{- end }}

--- a/charts/accessnode/templates/deploy.yaml
+++ b/charts/accessnode/templates/deploy.yaml
@@ -20,6 +20,8 @@ spec:
   template:
     metadata:
       name: {{ $objectname }}
+      annotations:
+        commvault.com/install-layout: {{ include "cv.installLayoutVersion" . | trim | quote }}
       labels:
         app.kubernetes.io/name: {{ $objectname }}
     spec:
@@ -51,7 +53,7 @@ spec:
         # This can be left with default settings as mentioned in this template.
         {{- include "cv.commonVolumeMounts" . }}
         - name: cv-storage-jobresults
-          mountPath: /opt/{{include "cv.utils.getOemPath" .}}/iDataAgent/jobResults
+          mountPath: {{include "cv.paths.jobResults" .}}
           subPath: jobResults
         {{- include "cv.additionalVolumeMounts" . }}
         {{ include "cv.commonContainerSpecs" . }}

--- a/charts/accessnode/templates/deploy.yaml
+++ b/charts/accessnode/templates/deploy.yaml
@@ -8,7 +8,11 @@ kind: {{ if $statefulset }}StatefulSet{{ else }}Deployment{{ end }}
 metadata:
   name: {{ $objectname }}
   namespace: {{ include "cv.namespace" . }}
-  {{- include "cv.deploymentannotations" . }}
+  annotations:
+    commvault.com/install-layout: {{ include "cv.installLayoutVersion" . | trim | quote }}
+    {{- if or (.Values.global).deploymentannotations .Values.deploymentannotations }}
+{{- include "cv.utils.getCombinedYaml" (list .Values.deploymentannotations (.Values.global).deploymentannotations $ 4 true) }}
+    {{- end }}
   labels:
     app.kubernetes.io/name: {{ $objectname }}
 spec:

--- a/charts/commandcenter/Chart.yaml
+++ b/charts/commandcenter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: commandcenter
 description: A Helm chart for creating the command center
 type: application
-version: "1.0.9"
+version: "1.0.10"
 appVersion: "1"

--- a/charts/commandcenter/templates/_pvc.tpl
+++ b/charts/commandcenter/templates/_pvc.tpl
@@ -170,7 +170,7 @@ storageClass:
           subPath: Registry
         {{- end }}
         - name: cv-storage-certsandlogs
-          mountPath: /opt/{{include "cv.utils.getOemPath" .}}/appdata
+          mountPath: {{include "cv.paths.certMountPath" .}}
           subPath: certificates
         {{- if eq (include "cv.useInitContainer" .) "true" }}
         - name: cv-storage-certsandlogs

--- a/charts/commandcenter/templates/_utils.tpl
+++ b/charts/commandcenter/templates/_utils.tpl
@@ -233,3 +233,94 @@ Returns either commvault or metallic depending on the oem id
 {{- "commvault" }}
 {{- end }}
 {{- end }}
+
+{{/*
+Returns the CU/build number (3rd number) from the tag. e.g. 105 from 11.42.105.Rev1425
+Returns 0 if fewer than 3 numbers exist in the tag.
+*/}}
+{{- define "cv.utils.getCUPack" }}
+{{- $tag := include "cv.utils.getTag" . }}
+{{- $numbers := regexFindAll "(\\d+)" $tag 3 }}
+{{- if ge (len $numbers) 3 }}
+{{- atoi (index $numbers 2) }}
+{{- else }}
+{{- 0 }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns "true" if the image tag version is at least major.fr.cu
+Supports both 2-param (version, FR) and 3-param (version, FR, CU) checks.
+Usage:
+  {{- if eq (include "cv.utils.isMinVersion3" (list . 11 42 105)) "true" }}
+*/}}
+{{- define "cv.utils.isMinVersion3" }}
+{{- $root := index . 0 }}
+{{- $version := index . 1 }}
+{{- $fr := index . 2 }}
+{{- $cu := index . 3 }}
+{{- $curVer := atoi (include "cv.utils.getVersion" $root) }}
+{{- $curFR := atoi (include "cv.utils.getFeatureRelease" $root) }}
+{{- $curCU := atoi (include "cv.utils.getCUPack" $root) }}
+{{- if gt $curVer $version }}
+{{- printf "true" }}
+{{- else if lt $curVer $version }}
+{{- printf "false" }}
+{{- else if gt $curFR $fr }}
+{{- printf "true" }}
+{{- else if lt $curFR $fr }}
+{{- printf "false" }}
+{{- else if ge $curCU $cu }}
+{{- printf "true" }}
+{{- else }}
+{{- printf "false" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Determines the installation layout version (v1 or v2).
+Priority:
+  1. Explicit Helm value: global.installLayoutVersion
+  2. Existing deployment annotation: commvault.com/install-layout
+  3. Fresh install version inference (>= 11.42.105 → v2)
+  4. Fallback to v1
+*/}}
+{{- define "cv.installLayoutVersion" }}
+{{- if ((.Values.global).installLayoutVersion) }}
+{{- .Values.global.installLayoutVersion | trim }}
+{{- else }}
+{{- $objectname := include "cv.metadataname" . }}
+{{- $namespace := include "cv.namespace" . }}
+{{- $statefulset := or .Values.statefulset ((.Values).global).statefulset }}
+{{- $kind := "Deployment" }}
+{{- if $statefulset }}
+{{- $kind = "StatefulSet" }}
+{{- end }}
+{{- $existing := lookup "apps/v1" $kind $namespace $objectname }}
+{{- if and $existing $existing.metadata $existing.metadata.annotations (index $existing.metadata.annotations "commvault.com/install-layout") }}
+{{- index $existing.metadata.annotations "commvault.com/install-layout" | trim }}
+{{- else if not $existing }}
+{{- if eq (include "cv.utils.isMinVersion3" (list . 11 42 105)) "true" }}
+{{- printf "v2" }}
+{{- else }}
+{{- printf "v1" }}
+{{- end }}
+{{- else }}
+{{- printf "v1" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns the appdata certificate mount path based on layout version.
+v1: /opt/commvault/appdata (old path - PVC mounts here, certificates/ is a subdir inside)
+v2: /var/opt/commvault/Instance001/appdata/certificates (new path - PVC mounts directly at certificates dir)
+*/}}
+{{- define "cv.paths.certMountPath" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/appdata/certificates" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/%s/appdata" (include "cv.utils.getOemPath" .) }}
+{{- end }}
+{{- end }}

--- a/charts/commandcenter/templates/_utils.tpl
+++ b/charts/commandcenter/templates/_utils.tpl
@@ -324,3 +324,59 @@ v2: /var/opt/commvault/Instance001/appdata/certificates (new path - PVC mounts d
 {{- printf "/opt/%s/appdata" (include "cv.utils.getOemPath" .) }}
 {{- end }}
 {{- end }}
+
+{{/*
+Returns the appdata base path based on layout version.
+v1: /opt/commvault/appdata
+v2: /var/opt/commvault/Instance001/appdata
+*/}}
+{{- define "cv.paths.appdata" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/appdata" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/%s/appdata" (include "cv.utils.getOemPath" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns the jobResults path based on layout version.
+v1: /opt/commvault/iDataAgent/jobResults
+v2: /var/opt/commvault/Instance001/data/commvaultdata/jobResults
+*/}}
+{{- define "cv.paths.jobResults" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/data/commvaultdata/jobResults" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/%s/iDataAgent/jobResults" (include "cv.utils.getOemPath" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns the IndexCache path based on layout version.
+v1: /opt/commvault/MediaAgent/IndexCache
+v2: /var/opt/commvault/Instance001/data/commvaultdata/IndexCache
+*/}}
+{{- define "cv.paths.indexCache" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/data/commvaultdata/IndexCache" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/%s/MediaAgent/IndexCache" (include "cv.utils.getOemPath" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns the DDB path based on layout version.
+v1: /opt/ddb
+v2: /var/opt/commvault/Instance001/data/commvaultdata/DDB
+*/}}
+{{- define "cv.paths.ddb" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/data/commvaultdata/DDB" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/ddb" }}
+{{- end }}
+{{- end }}

--- a/charts/commandcenter/templates/deploy.yaml
+++ b/charts/commandcenter/templates/deploy.yaml
@@ -8,7 +8,11 @@ kind: {{ if $statefulset }}StatefulSet{{ else }}Deployment{{ end }}
 metadata:
   name: {{ $objectname }}
   namespace: {{ include "cv.namespace" . }}
-  {{- include "cv.deploymentannotations" . }}
+  annotations:
+    commvault.com/install-layout: {{ include "cv.installLayoutVersion" . | trim | quote }}
+    {{- if or (.Values.global).deploymentannotations .Values.deploymentannotations }}
+{{- include "cv.utils.getCombinedYaml" (list .Values.deploymentannotations (.Values.global).deploymentannotations $ 4 true) }}
+    {{- end }}
   labels:
     app.kubernetes.io/name: {{ $objectname }}
 spec:

--- a/charts/commandcenter/templates/deploy.yaml
+++ b/charts/commandcenter/templates/deploy.yaml
@@ -20,6 +20,8 @@ spec:
   template:
     metadata:
       name: {{ $objectname }}
+      annotations:
+        commvault.com/install-layout: {{ include "cv.installLayoutVersion" . | trim | quote }}
       labels:
         app.kubernetes.io/name: {{ $objectname }}
     spec:

--- a/charts/config/Chart.yaml
+++ b/charts/config/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: config
 description: A Helm chart for creating the base configuration and secret  for all cv components in the namespace
 type: application
-version: "1.0.10"
+version: "1.0.11"
 appVersion: "1"

--- a/charts/config/templates/_pvc.tpl
+++ b/charts/config/templates/_pvc.tpl
@@ -170,7 +170,7 @@ storageClass:
           subPath: Registry
         {{- end }}
         - name: cv-storage-certsandlogs
-          mountPath: /opt/{{include "cv.utils.getOemPath" .}}/appdata
+          mountPath: {{include "cv.paths.certMountPath" .}}
           subPath: certificates
         {{- if eq (include "cv.useInitContainer" .) "true" }}
         - name: cv-storage-certsandlogs

--- a/charts/config/templates/_utils.tpl
+++ b/charts/config/templates/_utils.tpl
@@ -233,3 +233,94 @@ Returns either commvault or metallic depending on the oem id
 {{- "commvault" }}
 {{- end }}
 {{- end }}
+
+{{/*
+Returns the CU/build number (3rd number) from the tag. e.g. 105 from 11.42.105.Rev1425
+Returns 0 if fewer than 3 numbers exist in the tag.
+*/}}
+{{- define "cv.utils.getCUPack" }}
+{{- $tag := include "cv.utils.getTag" . }}
+{{- $numbers := regexFindAll "(\\d+)" $tag 3 }}
+{{- if ge (len $numbers) 3 }}
+{{- atoi (index $numbers 2) }}
+{{- else }}
+{{- 0 }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns "true" if the image tag version is at least major.fr.cu
+Supports both 2-param (version, FR) and 3-param (version, FR, CU) checks.
+Usage:
+  {{- if eq (include "cv.utils.isMinVersion3" (list . 11 42 105)) "true" }}
+*/}}
+{{- define "cv.utils.isMinVersion3" }}
+{{- $root := index . 0 }}
+{{- $version := index . 1 }}
+{{- $fr := index . 2 }}
+{{- $cu := index . 3 }}
+{{- $curVer := atoi (include "cv.utils.getVersion" $root) }}
+{{- $curFR := atoi (include "cv.utils.getFeatureRelease" $root) }}
+{{- $curCU := atoi (include "cv.utils.getCUPack" $root) }}
+{{- if gt $curVer $version }}
+{{- printf "true" }}
+{{- else if lt $curVer $version }}
+{{- printf "false" }}
+{{- else if gt $curFR $fr }}
+{{- printf "true" }}
+{{- else if lt $curFR $fr }}
+{{- printf "false" }}
+{{- else if ge $curCU $cu }}
+{{- printf "true" }}
+{{- else }}
+{{- printf "false" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Determines the installation layout version (v1 or v2).
+Priority:
+  1. Explicit Helm value: global.installLayoutVersion
+  2. Existing deployment annotation: commvault.com/install-layout
+  3. Fresh install version inference (>= 11.42.105 → v2)
+  4. Fallback to v1
+*/}}
+{{- define "cv.installLayoutVersion" }}
+{{- if ((.Values.global).installLayoutVersion) }}
+{{- .Values.global.installLayoutVersion | trim }}
+{{- else }}
+{{- $objectname := include "cv.metadataname" . }}
+{{- $namespace := include "cv.namespace" . }}
+{{- $statefulset := or .Values.statefulset ((.Values).global).statefulset }}
+{{- $kind := "Deployment" }}
+{{- if $statefulset }}
+{{- $kind = "StatefulSet" }}
+{{- end }}
+{{- $existing := lookup "apps/v1" $kind $namespace $objectname }}
+{{- if and $existing $existing.metadata $existing.metadata.annotations (index $existing.metadata.annotations "commvault.com/install-layout") }}
+{{- index $existing.metadata.annotations "commvault.com/install-layout" | trim }}
+{{- else if not $existing }}
+{{- if eq (include "cv.utils.isMinVersion3" (list . 11 42 105)) "true" }}
+{{- printf "v2" }}
+{{- else }}
+{{- printf "v1" }}
+{{- end }}
+{{- else }}
+{{- printf "v1" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns the appdata certificate mount path based on layout version.
+v1: /opt/commvault/appdata (old path - PVC mounts here, certificates/ is a subdir inside)
+v2: /var/opt/commvault/Instance001/appdata/certificates (new path - PVC mounts directly at certificates dir)
+*/}}
+{{- define "cv.paths.certMountPath" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/appdata/certificates" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/%s/appdata" (include "cv.utils.getOemPath" .) }}
+{{- end }}
+{{- end }}

--- a/charts/config/templates/_utils.tpl
+++ b/charts/config/templates/_utils.tpl
@@ -324,3 +324,59 @@ v2: /var/opt/commvault/Instance001/appdata/certificates (new path - PVC mounts d
 {{- printf "/opt/%s/appdata" (include "cv.utils.getOemPath" .) }}
 {{- end }}
 {{- end }}
+
+{{/*
+Returns the appdata base path based on layout version.
+v1: /opt/commvault/appdata
+v2: /var/opt/commvault/Instance001/appdata
+*/}}
+{{- define "cv.paths.appdata" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/appdata" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/%s/appdata" (include "cv.utils.getOemPath" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns the jobResults path based on layout version.
+v1: /opt/commvault/iDataAgent/jobResults
+v2: /var/opt/commvault/Instance001/data/commvaultdata/jobResults
+*/}}
+{{- define "cv.paths.jobResults" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/data/commvaultdata/jobResults" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/%s/iDataAgent/jobResults" (include "cv.utils.getOemPath" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns the IndexCache path based on layout version.
+v1: /opt/commvault/MediaAgent/IndexCache
+v2: /var/opt/commvault/Instance001/data/commvaultdata/IndexCache
+*/}}
+{{- define "cv.paths.indexCache" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/data/commvaultdata/IndexCache" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/%s/MediaAgent/IndexCache" (include "cv.utils.getOemPath" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns the DDB path based on layout version.
+v1: /opt/ddb
+v2: /var/opt/commvault/Instance001/data/commvaultdata/DDB
+*/}}
+{{- define "cv.paths.ddb" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/data/commvaultdata/DDB" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/ddb" }}
+{{- end }}
+{{- end }}

--- a/charts/cs/Chart.yaml
+++ b/charts/cs/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: commserve
 description: A Helm chart for creating the CS component
 type: application
-version: "1.0.11"
+version: "1.0.12"
 appVersion: "1"

--- a/charts/cs/templates/_pvc.tpl
+++ b/charts/cs/templates/_pvc.tpl
@@ -170,7 +170,7 @@ storageClass:
           subPath: Registry
         {{- end }}
         - name: cv-storage-certsandlogs
-          mountPath: /opt/{{include "cv.utils.getOemPath" .}}/appdata
+          mountPath: {{include "cv.paths.certMountPath" .}}
           subPath: certificates
         {{- if eq (include "cv.useInitContainer" .) "true" }}
         - name: cv-storage-certsandlogs

--- a/charts/cs/templates/_utils.tpl
+++ b/charts/cs/templates/_utils.tpl
@@ -297,7 +297,7 @@ Priority:
 {{- $kind = "StatefulSet" }}
 {{- end }}
 {{- $existing := lookup "apps/v1" $kind $namespace $objectname }}
-{{- if and $existing $existing.metadata $existing.metadata.annotations (index $existing.metadata.annotations "commvault.com/install-layout") }}
+{{- if and $existing $existing.metadata $existing.metadata.annotations (index $existing.metadata.annotations "commvault.com/install-layout" ) }}
 {{- index $existing.metadata.annotations "commvault.com/install-layout" | trim }}
 {{- else if not $existing }}
 {{- if eq (include "cv.utils.isMinVersion3" (list . 11 42 105)) "true" }}
@@ -322,5 +322,61 @@ v2: /var/opt/commvault/Instance001/appdata/certificates (new path - PVC mounts d
 {{- printf "/var/opt/%s/Instance001/appdata/certificates" (include "cv.utils.getOemPath" .) }}
 {{- else }}
 {{- printf "/opt/%s/appdata" (include "cv.utils.getOemPath" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns the appdata base path based on layout version.
+v1: /opt/commvault/appdata
+v2: /var/opt/commvault/Instance001/appdata
+*/}}
+{{- define "cv.paths.appdata" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/appdata" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/%s/appdata" (include "cv.utils.getOemPath" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns the jobResults path based on layout version.
+v1: /opt/commvault/iDataAgent/jobResults
+v2: /var/opt/commvault/Instance001/data/commvaultdata/jobResults
+*/}}
+{{- define "cv.paths.jobResults" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/data/commvaultdata/jobResults" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/%s/iDataAgent/jobResults" (include "cv.utils.getOemPath" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns the IndexCache path based on layout version.
+v1: /opt/commvault/MediaAgent/IndexCache
+v2: /var/opt/commvault/Instance001/data/commvaultdata/IndexCache
+*/}}
+{{- define "cv.paths.indexCache" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/data/commvaultdata/IndexCache" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/%s/MediaAgent/IndexCache" (include "cv.utils.getOemPath" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns the DDB path based on layout version.
+v1: /opt/ddb
+v2: /var/opt/commvault/Instance001/data/commvaultdata/DDB
+*/}}
+{{- define "cv.paths.ddb" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/data/commvaultdata/DDB" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/ddb" }}
 {{- end }}
 {{- end }}

--- a/charts/cs/templates/_utils.tpl
+++ b/charts/cs/templates/_utils.tpl
@@ -233,3 +233,94 @@ Returns either commvault or metallic depending on the oem id
 {{- "commvault" }}
 {{- end }}
 {{- end }}
+
+{{/*
+Returns the CU/build number (3rd number) from the tag. e.g. 105 from 11.42.105.Rev1425
+Returns 0 if fewer than 3 numbers exist in the tag.
+*/}}
+{{- define "cv.utils.getCUPack" }}
+{{- $tag := include "cv.utils.getTag" . }}
+{{- $numbers := regexFindAll "(\\d+)" $tag 3 }}
+{{- if ge (len $numbers) 3 }}
+{{- atoi (index $numbers 2) }}
+{{- else }}
+{{- 0 }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns "true" if the image tag version is at least major.fr.cu
+Supports both 2-param (version, FR) and 3-param (version, FR, CU) checks.
+Usage:
+  {{- if eq (include "cv.utils.isMinVersion3" (list . 11 42 105)) "true" }}
+*/}}
+{{- define "cv.utils.isMinVersion3" }}
+{{- $root := index . 0 }}
+{{- $version := index . 1 }}
+{{- $fr := index . 2 }}
+{{- $cu := index . 3 }}
+{{- $curVer := atoi (include "cv.utils.getVersion" $root) }}
+{{- $curFR := atoi (include "cv.utils.getFeatureRelease" $root) }}
+{{- $curCU := atoi (include "cv.utils.getCUPack" $root) }}
+{{- if gt $curVer $version }}
+{{- printf "true" }}
+{{- else if lt $curVer $version }}
+{{- printf "false" }}
+{{- else if gt $curFR $fr }}
+{{- printf "true" }}
+{{- else if lt $curFR $fr }}
+{{- printf "false" }}
+{{- else if ge $curCU $cu }}
+{{- printf "true" }}
+{{- else }}
+{{- printf "false" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Determines the installation layout version (v1 or v2).
+Priority:
+  1. Explicit Helm value: global.installLayoutVersion
+  2. Existing deployment annotation: commvault.com/install-layout
+  3. Fresh install version inference (>= 11.42.105 → v2)
+  4. Fallback to v1
+*/}}
+{{- define "cv.installLayoutVersion" }}
+{{- if ((.Values.global).installLayoutVersion) }}
+{{- .Values.global.installLayoutVersion | trim }}
+{{- else }}
+{{- $objectname := include "cv.metadataname" . }}
+{{- $namespace := include "cv.namespace" . }}
+{{- $statefulset := or .Values.statefulset ((.Values).global).statefulset }}
+{{- $kind := "Deployment" }}
+{{- if $statefulset }}
+{{- $kind = "StatefulSet" }}
+{{- end }}
+{{- $existing := lookup "apps/v1" $kind $namespace $objectname }}
+{{- if and $existing $existing.metadata $existing.metadata.annotations (index $existing.metadata.annotations "commvault.com/install-layout") }}
+{{- index $existing.metadata.annotations "commvault.com/install-layout" | trim }}
+{{- else if not $existing }}
+{{- if eq (include "cv.utils.isMinVersion3" (list . 11 42 105)) "true" }}
+{{- printf "v2" }}
+{{- else }}
+{{- printf "v1" }}
+{{- end }}
+{{- else }}
+{{- printf "v1" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns the appdata certificate mount path based on layout version.
+v1: /opt/commvault/appdata (old path - PVC mounts here, certificates/ is a subdir inside)
+v2: /var/opt/commvault/Instance001/appdata/certificates (new path - PVC mounts directly at certificates dir)
+*/}}
+{{- define "cv.paths.certMountPath" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/appdata/certificates" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/%s/appdata" (include "cv.utils.getOemPath" .) }}
+{{- end }}
+{{- end }}

--- a/charts/cs/templates/deploy.yaml
+++ b/charts/cs/templates/deploy.yaml
@@ -8,7 +8,11 @@ kind: {{ if $statefulset }}StatefulSet{{ else }}Deployment{{ end }}
 metadata:
   name: {{ $objectname }}
   namespace: {{ include "cv.namespace" . }}
-  {{- include "cv.deploymentannotations" . }}
+  annotations:
+    commvault.com/install-layout: {{ include "cv.installLayoutVersion" . | trim | quote }}
+    {{- if or (.Values.global).deploymentannotations .Values.deploymentannotations }}
+{{- include "cv.utils.getCombinedYaml" (list .Values.deploymentannotations (.Values.global).deploymentannotations $ 4 true) }}
+    {{- end }}
   labels:
     app.kubernetes.io/name: {{ $objectname }}
 spec:

--- a/charts/cs/templates/deploy.yaml
+++ b/charts/cs/templates/deploy.yaml
@@ -20,6 +20,8 @@ spec:
   template:
     metadata:
       name: {{ $objectname }}
+      annotations:
+        commvault.com/install-layout: {{ include "cv.installLayoutVersion" . | trim | quote }}
       labels:
         app.kubernetes.io/name: {{ $objectname }}
     spec:

--- a/charts/cv-ddb-backup-role/Chart.yaml
+++ b/charts/cv-ddb-backup-role/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cv-ddb-backup-role
 description: A Helm chart for creating cluster role that enables service accounts to view cluster wide resources.
 type: application
-version: "1.0.9"
+version: "1.0.10"
 appVersion: "1"

--- a/charts/gcmserver/Chart.yaml
+++ b/charts/gcmserver/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: gcmserver
 description: A Helm chart for creating the gcmserver
 type: application
-version: "1.0.11"
+version: "1.0.12"
 appVersion: "1"

--- a/charts/gcmserver/templates/_pvc.tpl
+++ b/charts/gcmserver/templates/_pvc.tpl
@@ -170,7 +170,7 @@ storageClass:
           subPath: Registry
         {{- end }}
         - name: cv-storage-certsandlogs
-          mountPath: /opt/{{include "cv.utils.getOemPath" .}}/appdata
+          mountPath: {{include "cv.paths.certMountPath" .}}
           subPath: certificates
         {{- if eq (include "cv.useInitContainer" .) "true" }}
         - name: cv-storage-certsandlogs

--- a/charts/gcmserver/templates/_utils.tpl
+++ b/charts/gcmserver/templates/_utils.tpl
@@ -233,3 +233,94 @@ Returns either commvault or metallic depending on the oem id
 {{- "commvault" }}
 {{- end }}
 {{- end }}
+
+{{/*
+Returns the CU/build number (3rd number) from the tag. e.g. 105 from 11.42.105.Rev1425
+Returns 0 if fewer than 3 numbers exist in the tag.
+*/}}
+{{- define "cv.utils.getCUPack" }}
+{{- $tag := include "cv.utils.getTag" . }}
+{{- $numbers := regexFindAll "(\\d+)" $tag 3 }}
+{{- if ge (len $numbers) 3 }}
+{{- atoi (index $numbers 2) }}
+{{- else }}
+{{- 0 }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns "true" if the image tag version is at least major.fr.cu
+Supports both 2-param (version, FR) and 3-param (version, FR, CU) checks.
+Usage:
+  {{- if eq (include "cv.utils.isMinVersion3" (list . 11 42 105)) "true" }}
+*/}}
+{{- define "cv.utils.isMinVersion3" }}
+{{- $root := index . 0 }}
+{{- $version := index . 1 }}
+{{- $fr := index . 2 }}
+{{- $cu := index . 3 }}
+{{- $curVer := atoi (include "cv.utils.getVersion" $root) }}
+{{- $curFR := atoi (include "cv.utils.getFeatureRelease" $root) }}
+{{- $curCU := atoi (include "cv.utils.getCUPack" $root) }}
+{{- if gt $curVer $version }}
+{{- printf "true" }}
+{{- else if lt $curVer $version }}
+{{- printf "false" }}
+{{- else if gt $curFR $fr }}
+{{- printf "true" }}
+{{- else if lt $curFR $fr }}
+{{- printf "false" }}
+{{- else if ge $curCU $cu }}
+{{- printf "true" }}
+{{- else }}
+{{- printf "false" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Determines the installation layout version (v1 or v2).
+Priority:
+  1. Explicit Helm value: global.installLayoutVersion
+  2. Existing deployment annotation: commvault.com/install-layout
+  3. Fresh install version inference (>= 11.42.105 → v2)
+  4. Fallback to v1
+*/}}
+{{- define "cv.installLayoutVersion" }}
+{{- if ((.Values.global).installLayoutVersion) }}
+{{- .Values.global.installLayoutVersion | trim }}
+{{- else }}
+{{- $objectname := include "cv.metadataname" . }}
+{{- $namespace := include "cv.namespace" . }}
+{{- $statefulset := or .Values.statefulset ((.Values).global).statefulset }}
+{{- $kind := "Deployment" }}
+{{- if $statefulset }}
+{{- $kind = "StatefulSet" }}
+{{- end }}
+{{- $existing := lookup "apps/v1" $kind $namespace $objectname }}
+{{- if and $existing $existing.metadata $existing.metadata.annotations (index $existing.metadata.annotations "commvault.com/install-layout") }}
+{{- index $existing.metadata.annotations "commvault.com/install-layout" | trim }}
+{{- else if not $existing }}
+{{- if eq (include "cv.utils.isMinVersion3" (list . 11 42 105)) "true" }}
+{{- printf "v2" }}
+{{- else }}
+{{- printf "v1" }}
+{{- end }}
+{{- else }}
+{{- printf "v1" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns the appdata certificate mount path based on layout version.
+v1: /opt/commvault/appdata (old path - PVC mounts here, certificates/ is a subdir inside)
+v2: /var/opt/commvault/Instance001/appdata/certificates (new path - PVC mounts directly at certificates dir)
+*/}}
+{{- define "cv.paths.certMountPath" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/appdata/certificates" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/%s/appdata" (include "cv.utils.getOemPath" .) }}
+{{- end }}
+{{- end }}

--- a/charts/gcmserver/templates/_utils.tpl
+++ b/charts/gcmserver/templates/_utils.tpl
@@ -324,3 +324,59 @@ v2: /var/opt/commvault/Instance001/appdata/certificates (new path - PVC mounts d
 {{- printf "/opt/%s/appdata" (include "cv.utils.getOemPath" .) }}
 {{- end }}
 {{- end }}
+
+{{/*
+Returns the appdata base path based on layout version.
+v1: /opt/commvault/appdata
+v2: /var/opt/commvault/Instance001/appdata
+*/}}
+{{- define "cv.paths.appdata" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/appdata" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/%s/appdata" (include "cv.utils.getOemPath" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns the jobResults path based on layout version.
+v1: /opt/commvault/iDataAgent/jobResults
+v2: /var/opt/commvault/Instance001/data/commvaultdata/jobResults
+*/}}
+{{- define "cv.paths.jobResults" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/data/commvaultdata/jobResults" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/%s/iDataAgent/jobResults" (include "cv.utils.getOemPath" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns the IndexCache path based on layout version.
+v1: /opt/commvault/MediaAgent/IndexCache
+v2: /var/opt/commvault/Instance001/data/commvaultdata/IndexCache
+*/}}
+{{- define "cv.paths.indexCache" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/data/commvaultdata/IndexCache" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/%s/MediaAgent/IndexCache" (include "cv.utils.getOemPath" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns the DDB path based on layout version.
+v1: /opt/ddb
+v2: /var/opt/commvault/Instance001/data/commvaultdata/DDB
+*/}}
+{{- define "cv.paths.ddb" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/data/commvaultdata/DDB" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/ddb" }}
+{{- end }}
+{{- end }}

--- a/charts/gcmserver/templates/deploy.yaml
+++ b/charts/gcmserver/templates/deploy.yaml
@@ -8,7 +8,11 @@ kind: {{ if $statefulset }}StatefulSet{{ else }}Deployment{{ end }}
 metadata:
   name: {{ $objectname }}
   namespace: {{ include "cv.namespace" . }}
-  {{- include "cv.deploymentannotations" . }}
+  annotations:
+    commvault.com/install-layout: {{ include "cv.installLayoutVersion" . | trim | quote }}
+    {{- if or (.Values.global).deploymentannotations .Values.deploymentannotations }}
+{{- include "cv.utils.getCombinedYaml" (list .Values.deploymentannotations (.Values.global).deploymentannotations $ 4 true) }}
+    {{- end }}
   labels:
     app.kubernetes.io/name: {{ $objectname }}
 spec:

--- a/charts/gcmserver/templates/deploy.yaml
+++ b/charts/gcmserver/templates/deploy.yaml
@@ -20,6 +20,8 @@ spec:
   template:
     metadata:
       name: {{ $objectname }}
+      annotations:
+        commvault.com/install-layout: {{ include "cv.installLayoutVersion" . | trim | quote }}
       labels:
         app.kubernetes.io/name: {{ $objectname }}
     spec:

--- a/charts/hubserver/Chart.yaml
+++ b/charts/hubserver/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: hubserver
 description: A Helm chart for creating the hubserver
 type: application
-version: "1.0.11"
+version: "1.0.12"
 appVersion: "1"

--- a/charts/hubserver/templates/_pvc.tpl
+++ b/charts/hubserver/templates/_pvc.tpl
@@ -170,7 +170,7 @@ storageClass:
           subPath: Registry
         {{- end }}
         - name: cv-storage-certsandlogs
-          mountPath: /opt/{{include "cv.utils.getOemPath" .}}/appdata
+          mountPath: {{include "cv.paths.certMountPath" .}}
           subPath: certificates
         {{- if eq (include "cv.useInitContainer" .) "true" }}
         - name: cv-storage-certsandlogs

--- a/charts/hubserver/templates/_utils.tpl
+++ b/charts/hubserver/templates/_utils.tpl
@@ -233,3 +233,94 @@ Returns either commvault or metallic depending on the oem id
 {{- "commvault" }}
 {{- end }}
 {{- end }}
+
+{{/*
+Returns the CU/build number (3rd number) from the tag. e.g. 105 from 11.42.105.Rev1425
+Returns 0 if fewer than 3 numbers exist in the tag.
+*/}}
+{{- define "cv.utils.getCUPack" }}
+{{- $tag := include "cv.utils.getTag" . }}
+{{- $numbers := regexFindAll "(\\d+)" $tag 3 }}
+{{- if ge (len $numbers) 3 }}
+{{- atoi (index $numbers 2) }}
+{{- else }}
+{{- 0 }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns "true" if the image tag version is at least major.fr.cu
+Supports both 2-param (version, FR) and 3-param (version, FR, CU) checks.
+Usage:
+  {{- if eq (include "cv.utils.isMinVersion3" (list . 11 42 105)) "true" }}
+*/}}
+{{- define "cv.utils.isMinVersion3" }}
+{{- $root := index . 0 }}
+{{- $version := index . 1 }}
+{{- $fr := index . 2 }}
+{{- $cu := index . 3 }}
+{{- $curVer := atoi (include "cv.utils.getVersion" $root) }}
+{{- $curFR := atoi (include "cv.utils.getFeatureRelease" $root) }}
+{{- $curCU := atoi (include "cv.utils.getCUPack" $root) }}
+{{- if gt $curVer $version }}
+{{- printf "true" }}
+{{- else if lt $curVer $version }}
+{{- printf "false" }}
+{{- else if gt $curFR $fr }}
+{{- printf "true" }}
+{{- else if lt $curFR $fr }}
+{{- printf "false" }}
+{{- else if ge $curCU $cu }}
+{{- printf "true" }}
+{{- else }}
+{{- printf "false" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Determines the installation layout version (v1 or v2).
+Priority:
+  1. Explicit Helm value: global.installLayoutVersion
+  2. Existing deployment annotation: commvault.com/install-layout
+  3. Fresh install version inference (>= 11.42.105 → v2)
+  4. Fallback to v1
+*/}}
+{{- define "cv.installLayoutVersion" }}
+{{- if ((.Values.global).installLayoutVersion) }}
+{{- .Values.global.installLayoutVersion | trim }}
+{{- else }}
+{{- $objectname := include "cv.metadataname" . }}
+{{- $namespace := include "cv.namespace" . }}
+{{- $statefulset := or .Values.statefulset ((.Values).global).statefulset }}
+{{- $kind := "Deployment" }}
+{{- if $statefulset }}
+{{- $kind = "StatefulSet" }}
+{{- end }}
+{{- $existing := lookup "apps/v1" $kind $namespace $objectname }}
+{{- if and $existing $existing.metadata $existing.metadata.annotations (index $existing.metadata.annotations "commvault.com/install-layout") }}
+{{- index $existing.metadata.annotations "commvault.com/install-layout" | trim }}
+{{- else if not $existing }}
+{{- if eq (include "cv.utils.isMinVersion3" (list . 11 42 105)) "true" }}
+{{- printf "v2" }}
+{{- else }}
+{{- printf "v1" }}
+{{- end }}
+{{- else }}
+{{- printf "v1" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns the appdata certificate mount path based on layout version.
+v1: /opt/commvault/appdata (old path - PVC mounts here, certificates/ is a subdir inside)
+v2: /var/opt/commvault/Instance001/appdata/certificates (new path - PVC mounts directly at certificates dir)
+*/}}
+{{- define "cv.paths.certMountPath" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/appdata/certificates" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/%s/appdata" (include "cv.utils.getOemPath" .) }}
+{{- end }}
+{{- end }}

--- a/charts/hubserver/templates/_utils.tpl
+++ b/charts/hubserver/templates/_utils.tpl
@@ -324,3 +324,59 @@ v2: /var/opt/commvault/Instance001/appdata/certificates (new path - PVC mounts d
 {{- printf "/opt/%s/appdata" (include "cv.utils.getOemPath" .) }}
 {{- end }}
 {{- end }}
+
+{{/*
+Returns the appdata base path based on layout version.
+v1: /opt/commvault/appdata
+v2: /var/opt/commvault/Instance001/appdata
+*/}}
+{{- define "cv.paths.appdata" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/appdata" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/%s/appdata" (include "cv.utils.getOemPath" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns the jobResults path based on layout version.
+v1: /opt/commvault/iDataAgent/jobResults
+v2: /var/opt/commvault/Instance001/data/commvaultdata/jobResults
+*/}}
+{{- define "cv.paths.jobResults" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/data/commvaultdata/jobResults" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/%s/iDataAgent/jobResults" (include "cv.utils.getOemPath" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns the IndexCache path based on layout version.
+v1: /opt/commvault/MediaAgent/IndexCache
+v2: /var/opt/commvault/Instance001/data/commvaultdata/IndexCache
+*/}}
+{{- define "cv.paths.indexCache" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/data/commvaultdata/IndexCache" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/%s/MediaAgent/IndexCache" (include "cv.utils.getOemPath" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns the DDB path based on layout version.
+v1: /opt/ddb
+v2: /var/opt/commvault/Instance001/data/commvaultdata/DDB
+*/}}
+{{- define "cv.paths.ddb" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/data/commvaultdata/DDB" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/ddb" }}
+{{- end }}
+{{- end }}

--- a/charts/hubserver/templates/deploy.yaml
+++ b/charts/hubserver/templates/deploy.yaml
@@ -8,7 +8,11 @@ kind: {{ if $statefulset }}StatefulSet{{ else }}Deployment{{ end }}
 metadata:
   name: {{ $objectname }}
   namespace: {{ include "cv.namespace" . }}
-  {{- include "cv.deploymentannotations" . }}
+  annotations:
+    commvault.com/install-layout: {{ include "cv.installLayoutVersion" . | trim | quote }}
+    {{- if or (.Values.global).deploymentannotations .Values.deploymentannotations }}
+{{- include "cv.utils.getCombinedYaml" (list .Values.deploymentannotations (.Values.global).deploymentannotations $ 4 true) }}
+    {{- end }}
   labels:
     app.kubernetes.io/name: {{ $objectname }}
 spec:

--- a/charts/hubserver/templates/deploy.yaml
+++ b/charts/hubserver/templates/deploy.yaml
@@ -20,6 +20,8 @@ spec:
   template:
     metadata:
       name: {{ $objectname }}
+      annotations:
+        commvault.com/install-layout: {{ include "cv.installLayoutVersion" . | trim | quote }}
       labels:
         app.kubernetes.io/name: {{ $objectname }}
     spec:

--- a/charts/mediaagent/Chart.yaml
+++ b/charts/mediaagent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: mediaagent
 description: A Helm chart for creating a media agent
 type: application
-version: "1.0.9"
+version: "1.0.10"
 appVersion: "1"

--- a/charts/mediaagent/templates/_pvc.tpl
+++ b/charts/mediaagent/templates/_pvc.tpl
@@ -170,7 +170,7 @@ storageClass:
           subPath: Registry
         {{- end }}
         - name: cv-storage-certsandlogs
-          mountPath: /opt/{{include "cv.utils.getOemPath" .}}/appdata
+          mountPath: {{include "cv.paths.certMountPath" .}}
           subPath: certificates
         {{- if eq (include "cv.useInitContainer" .) "true" }}
         - name: cv-storage-certsandlogs

--- a/charts/mediaagent/templates/_utils.tpl
+++ b/charts/mediaagent/templates/_utils.tpl
@@ -233,3 +233,94 @@ Returns either commvault or metallic depending on the oem id
 {{- "commvault" }}
 {{- end }}
 {{- end }}
+
+{{/*
+Returns the CU/build number (3rd number) from the tag. e.g. 105 from 11.42.105.Rev1425
+Returns 0 if fewer than 3 numbers exist in the tag.
+*/}}
+{{- define "cv.utils.getCUPack" }}
+{{- $tag := include "cv.utils.getTag" . }}
+{{- $numbers := regexFindAll "(\\d+)" $tag 3 }}
+{{- if ge (len $numbers) 3 }}
+{{- atoi (index $numbers 2) }}
+{{- else }}
+{{- 0 }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns "true" if the image tag version is at least major.fr.cu
+Supports both 2-param (version, FR) and 3-param (version, FR, CU) checks.
+Usage:
+  {{- if eq (include "cv.utils.isMinVersion3" (list . 11 42 105)) "true" }}
+*/}}
+{{- define "cv.utils.isMinVersion3" }}
+{{- $root := index . 0 }}
+{{- $version := index . 1 }}
+{{- $fr := index . 2 }}
+{{- $cu := index . 3 }}
+{{- $curVer := atoi (include "cv.utils.getVersion" $root) }}
+{{- $curFR := atoi (include "cv.utils.getFeatureRelease" $root) }}
+{{- $curCU := atoi (include "cv.utils.getCUPack" $root) }}
+{{- if gt $curVer $version }}
+{{- printf "true" }}
+{{- else if lt $curVer $version }}
+{{- printf "false" }}
+{{- else if gt $curFR $fr }}
+{{- printf "true" }}
+{{- else if lt $curFR $fr }}
+{{- printf "false" }}
+{{- else if ge $curCU $cu }}
+{{- printf "true" }}
+{{- else }}
+{{- printf "false" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Determines the installation layout version (v1 or v2).
+Priority:
+  1. Explicit Helm value: global.installLayoutVersion
+  2. Existing deployment annotation: commvault.com/install-layout
+  3. Fresh install version inference (>= 11.42.105 → v2)
+  4. Fallback to v1
+*/}}
+{{- define "cv.installLayoutVersion" }}
+{{- if ((.Values.global).installLayoutVersion) }}
+{{- .Values.global.installLayoutVersion | trim }}
+{{- else }}
+{{- $objectname := include "cv.metadataname" . }}
+{{- $namespace := include "cv.namespace" . }}
+{{- $statefulset := or .Values.statefulset ((.Values).global).statefulset }}
+{{- $kind := "Deployment" }}
+{{- if $statefulset }}
+{{- $kind = "StatefulSet" }}
+{{- end }}
+{{- $existing := lookup "apps/v1" $kind $namespace $objectname }}
+{{- if and $existing $existing.metadata $existing.metadata.annotations (index $existing.metadata.annotations "commvault.com/install-layout") }}
+{{- index $existing.metadata.annotations "commvault.com/install-layout" | trim }}
+{{- else if not $existing }}
+{{- if eq (include "cv.utils.isMinVersion3" (list . 11 42 105)) "true" }}
+{{- printf "v2" }}
+{{- else }}
+{{- printf "v1" }}
+{{- end }}
+{{- else }}
+{{- printf "v1" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns the appdata certificate mount path based on layout version.
+v1: /opt/commvault/appdata (old path - PVC mounts here, certificates/ is a subdir inside)
+v2: /var/opt/commvault/Instance001/appdata/certificates (new path - PVC mounts directly at certificates dir)
+*/}}
+{{- define "cv.paths.certMountPath" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/appdata/certificates" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/%s/appdata" (include "cv.utils.getOemPath" .) }}
+{{- end }}
+{{- end }}

--- a/charts/mediaagent/templates/_utils.tpl
+++ b/charts/mediaagent/templates/_utils.tpl
@@ -324,3 +324,59 @@ v2: /var/opt/commvault/Instance001/appdata/certificates (new path - PVC mounts d
 {{- printf "/opt/%s/appdata" (include "cv.utils.getOemPath" .) }}
 {{- end }}
 {{- end }}
+
+{{/*
+Returns the appdata base path based on layout version.
+v1: /opt/commvault/appdata
+v2: /var/opt/commvault/Instance001/appdata
+*/}}
+{{- define "cv.paths.appdata" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/appdata" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/%s/appdata" (include "cv.utils.getOemPath" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns the jobResults path based on layout version.
+v1: /opt/commvault/iDataAgent/jobResults
+v2: /var/opt/commvault/Instance001/data/commvaultdata/jobResults
+*/}}
+{{- define "cv.paths.jobResults" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/data/commvaultdata/jobResults" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/%s/iDataAgent/jobResults" (include "cv.utils.getOemPath" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns the IndexCache path based on layout version.
+v1: /opt/commvault/MediaAgent/IndexCache
+v2: /var/opt/commvault/Instance001/data/commvaultdata/IndexCache
+*/}}
+{{- define "cv.paths.indexCache" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/data/commvaultdata/IndexCache" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/%s/MediaAgent/IndexCache" (include "cv.utils.getOemPath" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns the DDB path based on layout version.
+v1: /opt/ddb
+v2: /var/opt/commvault/Instance001/data/commvaultdata/DDB
+*/}}
+{{- define "cv.paths.ddb" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/data/commvaultdata/DDB" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/ddb" }}
+{{- end }}
+{{- end }}

--- a/charts/mediaagent/templates/deploy.yaml
+++ b/charts/mediaagent/templates/deploy.yaml
@@ -20,6 +20,8 @@ spec:
   template:
     metadata:
       name: {{ $objectname }}
+      annotations:
+        commvault.com/install-layout: {{ include "cv.installLayoutVersion" . | trim | quote }}
       labels:
         app.kubernetes.io/name: {{ $objectname }}
     spec:
@@ -52,13 +54,13 @@ spec:
         # This can be left with default settings as mentioned in this template.
         {{- include "cv.commonVolumeMounts" . }}
         - name: cv-storage-jobresults
-          mountPath: /opt/{{include "cv.utils.getOemPath" .}}/iDataAgent/jobResults
+          mountPath: {{include "cv.paths.jobResults" .}}
           subPath: jobResults
         - name: cv-storage-indexcache
-          mountPath: /opt/{{include "cv.utils.getOemPath" .}}/MediaAgent/IndexCache
+          mountPath: {{include "cv.paths.indexCache" .}}
           subPath: indexcache
         - name: cv-storage-ddb
-          mountPath: /opt/ddb
+          mountPath: {{include "cv.paths.ddb" .}}
           subPath: ddb
         {{- include "cv.additionalVolumeMounts" . }}
         {{ include "cv.commonContainerSpecs" . }}

--- a/charts/mediaagent/templates/deploy.yaml
+++ b/charts/mediaagent/templates/deploy.yaml
@@ -8,7 +8,11 @@ kind: {{ if $statefulset }}StatefulSet{{ else }}Deployment{{ end }}
 metadata:
   name: {{ $objectname }}
   namespace: {{ include "cv.namespace" . }}
-  {{- include "cv.deploymentannotations" . }}
+  annotations:
+    commvault.com/install-layout: {{ include "cv.installLayoutVersion" . | trim | quote }}
+    {{- if or (.Values.global).deploymentannotations .Values.deploymentannotations }}
+{{- include "cv.utils.getCombinedYaml" (list .Values.deploymentannotations (.Values.global).deploymentannotations $ 4 true) }}
+    {{- end }}
   labels:
     app.kubernetes.io/name: {{ $objectname }}
 spec:

--- a/charts/networkgateway/Chart.yaml
+++ b/charts/networkgateway/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: networkgateway
 description: A Helm chart for creating an FS agent which can serve as a network gateway
 type: application
-version: "1.0.9"
+version: "1.0.10"
 appVersion: "1"

--- a/charts/networkgateway/templates/_pvc.tpl
+++ b/charts/networkgateway/templates/_pvc.tpl
@@ -170,7 +170,7 @@ storageClass:
           subPath: Registry
         {{- end }}
         - name: cv-storage-certsandlogs
-          mountPath: /opt/{{include "cv.utils.getOemPath" .}}/appdata
+          mountPath: {{include "cv.paths.certMountPath" .}}
           subPath: certificates
         {{- if eq (include "cv.useInitContainer" .) "true" }}
         - name: cv-storage-certsandlogs

--- a/charts/networkgateway/templates/_utils.tpl
+++ b/charts/networkgateway/templates/_utils.tpl
@@ -233,3 +233,94 @@ Returns either commvault or metallic depending on the oem id
 {{- "commvault" }}
 {{- end }}
 {{- end }}
+
+{{/*
+Returns the CU/build number (3rd number) from the tag. e.g. 105 from 11.42.105.Rev1425
+Returns 0 if fewer than 3 numbers exist in the tag.
+*/}}
+{{- define "cv.utils.getCUPack" }}
+{{- $tag := include "cv.utils.getTag" . }}
+{{- $numbers := regexFindAll "(\\d+)" $tag 3 }}
+{{- if ge (len $numbers) 3 }}
+{{- atoi (index $numbers 2) }}
+{{- else }}
+{{- 0 }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns "true" if the image tag version is at least major.fr.cu
+Supports both 2-param (version, FR) and 3-param (version, FR, CU) checks.
+Usage:
+  {{- if eq (include "cv.utils.isMinVersion3" (list . 11 42 105)) "true" }}
+*/}}
+{{- define "cv.utils.isMinVersion3" }}
+{{- $root := index . 0 }}
+{{- $version := index . 1 }}
+{{- $fr := index . 2 }}
+{{- $cu := index . 3 }}
+{{- $curVer := atoi (include "cv.utils.getVersion" $root) }}
+{{- $curFR := atoi (include "cv.utils.getFeatureRelease" $root) }}
+{{- $curCU := atoi (include "cv.utils.getCUPack" $root) }}
+{{- if gt $curVer $version }}
+{{- printf "true" }}
+{{- else if lt $curVer $version }}
+{{- printf "false" }}
+{{- else if gt $curFR $fr }}
+{{- printf "true" }}
+{{- else if lt $curFR $fr }}
+{{- printf "false" }}
+{{- else if ge $curCU $cu }}
+{{- printf "true" }}
+{{- else }}
+{{- printf "false" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Determines the installation layout version (v1 or v2).
+Priority:
+  1. Explicit Helm value: global.installLayoutVersion
+  2. Existing deployment annotation: commvault.com/install-layout
+  3. Fresh install version inference (>= 11.42.105 → v2)
+  4. Fallback to v1
+*/}}
+{{- define "cv.installLayoutVersion" }}
+{{- if ((.Values.global).installLayoutVersion) }}
+{{- .Values.global.installLayoutVersion | trim }}
+{{- else }}
+{{- $objectname := include "cv.metadataname" . }}
+{{- $namespace := include "cv.namespace" . }}
+{{- $statefulset := or .Values.statefulset ((.Values).global).statefulset }}
+{{- $kind := "Deployment" }}
+{{- if $statefulset }}
+{{- $kind = "StatefulSet" }}
+{{- end }}
+{{- $existing := lookup "apps/v1" $kind $namespace $objectname }}
+{{- if and $existing $existing.metadata $existing.metadata.annotations (index $existing.metadata.annotations "commvault.com/install-layout") }}
+{{- index $existing.metadata.annotations "commvault.com/install-layout" | trim }}
+{{- else if not $existing }}
+{{- if eq (include "cv.utils.isMinVersion3" (list . 11 42 105)) "true" }}
+{{- printf "v2" }}
+{{- else }}
+{{- printf "v1" }}
+{{- end }}
+{{- else }}
+{{- printf "v1" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns the appdata certificate mount path based on layout version.
+v1: /opt/commvault/appdata (old path - PVC mounts here, certificates/ is a subdir inside)
+v2: /var/opt/commvault/Instance001/appdata/certificates (new path - PVC mounts directly at certificates dir)
+*/}}
+{{- define "cv.paths.certMountPath" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/appdata/certificates" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/%s/appdata" (include "cv.utils.getOemPath" .) }}
+{{- end }}
+{{- end }}

--- a/charts/networkgateway/templates/_utils.tpl
+++ b/charts/networkgateway/templates/_utils.tpl
@@ -324,3 +324,59 @@ v2: /var/opt/commvault/Instance001/appdata/certificates (new path - PVC mounts d
 {{- printf "/opt/%s/appdata" (include "cv.utils.getOemPath" .) }}
 {{- end }}
 {{- end }}
+
+{{/*
+Returns the appdata base path based on layout version.
+v1: /opt/commvault/appdata
+v2: /var/opt/commvault/Instance001/appdata
+*/}}
+{{- define "cv.paths.appdata" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/appdata" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/%s/appdata" (include "cv.utils.getOemPath" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns the jobResults path based on layout version.
+v1: /opt/commvault/iDataAgent/jobResults
+v2: /var/opt/commvault/Instance001/data/commvaultdata/jobResults
+*/}}
+{{- define "cv.paths.jobResults" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/data/commvaultdata/jobResults" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/%s/iDataAgent/jobResults" (include "cv.utils.getOemPath" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns the IndexCache path based on layout version.
+v1: /opt/commvault/MediaAgent/IndexCache
+v2: /var/opt/commvault/Instance001/data/commvaultdata/IndexCache
+*/}}
+{{- define "cv.paths.indexCache" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/data/commvaultdata/IndexCache" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/%s/MediaAgent/IndexCache" (include "cv.utils.getOemPath" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns the DDB path based on layout version.
+v1: /opt/ddb
+v2: /var/opt/commvault/Instance001/data/commvaultdata/DDB
+*/}}
+{{- define "cv.paths.ddb" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/data/commvaultdata/DDB" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/ddb" }}
+{{- end }}
+{{- end }}

--- a/charts/networkgateway/templates/deploy.yaml
+++ b/charts/networkgateway/templates/deploy.yaml
@@ -8,7 +8,11 @@ kind: {{ if $statefulset }}StatefulSet{{ else }}Deployment{{ end }}
 metadata:
   name: {{ $objectname }}
   namespace: {{ include "cv.namespace" . }}
-  {{- include "cv.deploymentannotations" . }}
+  annotations:
+    commvault.com/install-layout: {{ include "cv.installLayoutVersion" . | trim | quote }}
+    {{- if or (.Values.global).deploymentannotations .Values.deploymentannotations }}
+{{- include "cv.utils.getCombinedYaml" (list .Values.deploymentannotations (.Values.global).deploymentannotations $ 4 true) }}
+    {{- end }}
   labels:
     app.kubernetes.io/name: {{ $objectname }}
 spec:

--- a/charts/networkgateway/templates/deploy.yaml
+++ b/charts/networkgateway/templates/deploy.yaml
@@ -20,6 +20,8 @@ spec:
   template:
     metadata:
       name: {{ $objectname }}
+      annotations:
+        commvault.com/install-layout: {{ include "cv.installLayoutVersion" . | trim | quote }}
       labels:
         app.kubernetes.io/name: {{ $objectname }}
     spec:

--- a/charts/webserver/Chart.yaml
+++ b/charts/webserver/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: webserver
 description: A Helm chart for creating the webserver
 type: application
-version: "1.0.11"
+version: "1.0.12"
 appVersion: "1"

--- a/charts/webserver/templates/_pvc.tpl
+++ b/charts/webserver/templates/_pvc.tpl
@@ -170,7 +170,7 @@ storageClass:
           subPath: Registry
         {{- end }}
         - name: cv-storage-certsandlogs
-          mountPath: /opt/{{include "cv.utils.getOemPath" .}}/appdata
+          mountPath: {{include "cv.paths.certMountPath" .}}
           subPath: certificates
         {{- if eq (include "cv.useInitContainer" .) "true" }}
         - name: cv-storage-certsandlogs

--- a/charts/webserver/templates/_utils.tpl
+++ b/charts/webserver/templates/_utils.tpl
@@ -233,3 +233,94 @@ Returns either commvault or metallic depending on the oem id
 {{- "commvault" }}
 {{- end }}
 {{- end }}
+
+{{/*
+Returns the CU/build number (3rd number) from the tag. e.g. 105 from 11.42.105.Rev1425
+Returns 0 if fewer than 3 numbers exist in the tag.
+*/}}
+{{- define "cv.utils.getCUPack" }}
+{{- $tag := include "cv.utils.getTag" . }}
+{{- $numbers := regexFindAll "(\\d+)" $tag 3 }}
+{{- if ge (len $numbers) 3 }}
+{{- atoi (index $numbers 2) }}
+{{- else }}
+{{- 0 }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns "true" if the image tag version is at least major.fr.cu
+Supports both 2-param (version, FR) and 3-param (version, FR, CU) checks.
+Usage:
+  {{- if eq (include "cv.utils.isMinVersion3" (list . 11 42 105)) "true" }}
+*/}}
+{{- define "cv.utils.isMinVersion3" }}
+{{- $root := index . 0 }}
+{{- $version := index . 1 }}
+{{- $fr := index . 2 }}
+{{- $cu := index . 3 }}
+{{- $curVer := atoi (include "cv.utils.getVersion" $root) }}
+{{- $curFR := atoi (include "cv.utils.getFeatureRelease" $root) }}
+{{- $curCU := atoi (include "cv.utils.getCUPack" $root) }}
+{{- if gt $curVer $version }}
+{{- printf "true" }}
+{{- else if lt $curVer $version }}
+{{- printf "false" }}
+{{- else if gt $curFR $fr }}
+{{- printf "true" }}
+{{- else if lt $curFR $fr }}
+{{- printf "false" }}
+{{- else if ge $curCU $cu }}
+{{- printf "true" }}
+{{- else }}
+{{- printf "false" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Determines the installation layout version (v1 or v2).
+Priority:
+  1. Explicit Helm value: global.installLayoutVersion
+  2. Existing deployment annotation: commvault.com/install-layout
+  3. Fresh install version inference (>= 11.42.105 → v2)
+  4. Fallback to v1
+*/}}
+{{- define "cv.installLayoutVersion" }}
+{{- if ((.Values.global).installLayoutVersion) }}
+{{- .Values.global.installLayoutVersion | trim }}
+{{- else }}
+{{- $objectname := include "cv.metadataname" . }}
+{{- $namespace := include "cv.namespace" . }}
+{{- $statefulset := or .Values.statefulset ((.Values).global).statefulset }}
+{{- $kind := "Deployment" }}
+{{- if $statefulset }}
+{{- $kind = "StatefulSet" }}
+{{- end }}
+{{- $existing := lookup "apps/v1" $kind $namespace $objectname }}
+{{- if and $existing $existing.metadata $existing.metadata.annotations (index $existing.metadata.annotations "commvault.com/install-layout") }}
+{{- index $existing.metadata.annotations "commvault.com/install-layout" | trim }}
+{{- else if not $existing }}
+{{- if eq (include "cv.utils.isMinVersion3" (list . 11 42 105)) "true" }}
+{{- printf "v2" }}
+{{- else }}
+{{- printf "v1" }}
+{{- end }}
+{{- else }}
+{{- printf "v1" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns the appdata certificate mount path based on layout version.
+v1: /opt/commvault/appdata (old path - PVC mounts here, certificates/ is a subdir inside)
+v2: /var/opt/commvault/Instance001/appdata/certificates (new path - PVC mounts directly at certificates dir)
+*/}}
+{{- define "cv.paths.certMountPath" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/appdata/certificates" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/%s/appdata" (include "cv.utils.getOemPath" .) }}
+{{- end }}
+{{- end }}

--- a/charts/webserver/templates/_utils.tpl
+++ b/charts/webserver/templates/_utils.tpl
@@ -324,3 +324,59 @@ v2: /var/opt/commvault/Instance001/appdata/certificates (new path - PVC mounts d
 {{- printf "/opt/%s/appdata" (include "cv.utils.getOemPath" .) }}
 {{- end }}
 {{- end }}
+
+{{/*
+Returns the appdata base path based on layout version.
+v1: /opt/commvault/appdata
+v2: /var/opt/commvault/Instance001/appdata
+*/}}
+{{- define "cv.paths.appdata" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/appdata" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/%s/appdata" (include "cv.utils.getOemPath" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns the jobResults path based on layout version.
+v1: /opt/commvault/iDataAgent/jobResults
+v2: /var/opt/commvault/Instance001/data/commvaultdata/jobResults
+*/}}
+{{- define "cv.paths.jobResults" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/data/commvaultdata/jobResults" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/%s/iDataAgent/jobResults" (include "cv.utils.getOemPath" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns the IndexCache path based on layout version.
+v1: /opt/commvault/MediaAgent/IndexCache
+v2: /var/opt/commvault/Instance001/data/commvaultdata/IndexCache
+*/}}
+{{- define "cv.paths.indexCache" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/data/commvaultdata/IndexCache" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/%s/MediaAgent/IndexCache" (include "cv.utils.getOemPath" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns the DDB path based on layout version.
+v1: /opt/ddb
+v2: /var/opt/commvault/Instance001/data/commvaultdata/DDB
+*/}}
+{{- define "cv.paths.ddb" }}
+{{- $layout := include "cv.installLayoutVersion" . | trim }}
+{{- if eq $layout "v2" }}
+{{- printf "/var/opt/%s/Instance001/data/commvaultdata/DDB" (include "cv.utils.getOemPath" .) }}
+{{- else }}
+{{- printf "/opt/ddb" }}
+{{- end }}
+{{- end }}

--- a/charts/webserver/templates/deploy.yaml
+++ b/charts/webserver/templates/deploy.yaml
@@ -8,7 +8,11 @@ kind: {{ if $statefulset }}StatefulSet{{ else }}Deployment{{ end }}
 metadata:
   name: {{ $objectname }}
   namespace: {{ include "cv.namespace" . }}
-  {{- include "cv.deploymentannotations" . }}
+  annotations:
+    commvault.com/install-layout: {{ include "cv.installLayoutVersion" . | trim | quote }}
+    {{- if or (.Values.global).deploymentannotations .Values.deploymentannotations }}
+{{- include "cv.utils.getCombinedYaml" (list .Values.deploymentannotations (.Values.global).deploymentannotations $ 4 true) }}
+    {{- end }}
   labels:
     app.kubernetes.io/name: {{ $objectname }}
 spec:

--- a/charts/webserver/templates/deploy.yaml
+++ b/charts/webserver/templates/deploy.yaml
@@ -20,6 +20,8 @@ spec:
   template:
     metadata:
       name: {{ $objectname }}
+      annotations:
+        commvault.com/install-layout: {{ include "cv.installLayoutVersion" . | trim | quote }}
       labels:
         app.kubernetes.io/name: {{ $objectname }}
     spec:


### PR DESCRIPTION

Implement proper v1/v2 layout tagging per design spec:

- Add cv.utils.isMinVersion3: 3-param version check (major.SP.CU)
- Add cv.paths.certMountPath: resolves cert mount by layout version v1: /opt/commvault/appdata v2:/var/opt/commvault/Instance001/appdata/certificates
- Persist layout as immutable annotation on Deployment/StatefulSet

Test scenarios validated:
- Fresh install >= 11.42.105: v2 tag, new path mounted
- Fresh install < 11.42.105: v1 tag, old path mounted
- Upgrade from old (no annotation): v1 preserved
- Explicit override: global.installLayoutVersion takes priority

Applied to all 9 charts: accessnode, commandcenter, config, cs, gcmserver, hubserver, mediaagent, networkgateway, webserver.