### PR TITLE
fix(helm-charts): conditional cert mount subPath for v1/v2 install la…

### DIFF
--- a/charts/accessnode/Chart.yaml
+++ b/charts/accessnode/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: accessnode
 description: A Helm chart for creating an access node
 type: application
-version: "1.0.13"
+version: "1.0.14"
 appVersion: "1"

--- a/charts/accessnode/templates/_pvc.tpl
+++ b/charts/accessnode/templates/_pvc.tpl
@@ -169,9 +169,15 @@ storageClass:
           mountPath: /etc/CommVaultRegistry
           subPath: Registry
         {{- end }}
+        {{- if eq (include "cv.installLayoutVersion" . | trim) "v2" }}
         - name: cv-storage-certsandlogs
           mountPath: {{include "cv.paths.appdata" .}}
           subPath: appdata
+        {{- else }}
+        - name: cv-storage-certsandlogs
+          mountPath: {{include "cv.paths.certMountPath" .}}
+          subPath: certificates
+        {{- end }}
         {{- if eq (include "cv.useInitContainer" .) "true" }}
         - name: cv-storage-certsandlogs
           mountPath: /opt/{{include "cv.utils.getOemPath" .}}/k8ssecrets

--- a/charts/commandcenter/Chart.yaml
+++ b/charts/commandcenter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: commandcenter
 description: A Helm chart for creating the command center
 type: application
-version: "1.0.15"
+version: "1.0.16"
 appVersion: "1"

--- a/charts/commandcenter/templates/_pvc.tpl
+++ b/charts/commandcenter/templates/_pvc.tpl
@@ -169,9 +169,15 @@ storageClass:
           mountPath: /etc/CommVaultRegistry
           subPath: Registry
         {{- end }}
+        {{- if eq (include "cv.installLayoutVersion" . | trim) "v2" }}
         - name: cv-storage-certsandlogs
           mountPath: {{include "cv.paths.appdata" .}}
           subPath: appdata
+        {{- else }}
+        - name: cv-storage-certsandlogs
+          mountPath: {{include "cv.paths.certMountPath" .}}
+          subPath: certificates
+        {{- end }}
         {{- if eq (include "cv.useInitContainer" .) "true" }}
         - name: cv-storage-certsandlogs
           mountPath: /opt/{{include "cv.utils.getOemPath" .}}/k8ssecrets

--- a/charts/config/Chart.yaml
+++ b/charts/config/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: config
 description: A Helm chart for creating the base configuration and secret  for all cv components in the namespace
 type: application
-version: "1.0.13"
+version: "1.0.14"
 appVersion: "1"

--- a/charts/config/templates/_pvc.tpl
+++ b/charts/config/templates/_pvc.tpl
@@ -169,9 +169,15 @@ storageClass:
           mountPath: /etc/CommVaultRegistry
           subPath: Registry
         {{- end }}
+        {{- if eq (include "cv.installLayoutVersion" . | trim) "v2" }}
         - name: cv-storage-certsandlogs
           mountPath: {{include "cv.paths.appdata" .}}
           subPath: appdata
+        {{- else }}
+        - name: cv-storage-certsandlogs
+          mountPath: {{include "cv.paths.certMountPath" .}}
+          subPath: certificates
+        {{- end }}
         {{- if eq (include "cv.useInitContainer" .) "true" }}
         - name: cv-storage-certsandlogs
           mountPath: /opt/{{include "cv.utils.getOemPath" .}}/k8ssecrets

--- a/charts/cs/Chart.yaml
+++ b/charts/cs/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: commserve
 description: A Helm chart for creating the CS component
 type: application
-version: "1.0.15"
+version: "1.0.16"
 appVersion: "1"

--- a/charts/cs/templates/_pvc.tpl
+++ b/charts/cs/templates/_pvc.tpl
@@ -169,9 +169,15 @@ storageClass:
           mountPath: /etc/CommVaultRegistry
           subPath: Registry
         {{- end }}
+        {{- if eq (include "cv.installLayoutVersion" . | trim) "v2" }}
         - name: cv-storage-certsandlogs
           mountPath: {{include "cv.paths.appdata" .}}
           subPath: appdata
+        {{- else }}
+        - name: cv-storage-certsandlogs
+          mountPath: {{include "cv.paths.certMountPath" .}}
+          subPath: certificates
+        {{- end }}
         {{- if eq (include "cv.useInitContainer" .) "true" }}
         - name: cv-storage-certsandlogs
           mountPath: /opt/{{include "cv.utils.getOemPath" .}}/k8ssecrets

--- a/charts/gcmserver/Chart.yaml
+++ b/charts/gcmserver/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: gcmserver
 description: A Helm chart for creating the gcmserver
 type: application
-version: "1.0.15"
+version: "1.0.16"
 appVersion: "1"

--- a/charts/gcmserver/templates/_pvc.tpl
+++ b/charts/gcmserver/templates/_pvc.tpl
@@ -169,9 +169,15 @@ storageClass:
           mountPath: /etc/CommVaultRegistry
           subPath: Registry
         {{- end }}
+        {{- if eq (include "cv.installLayoutVersion" . | trim) "v2" }}
         - name: cv-storage-certsandlogs
           mountPath: {{include "cv.paths.appdata" .}}
           subPath: appdata
+        {{- else }}
+        - name: cv-storage-certsandlogs
+          mountPath: {{include "cv.paths.certMountPath" .}}
+          subPath: certificates
+        {{- end }}
         {{- if eq (include "cv.useInitContainer" .) "true" }}
         - name: cv-storage-certsandlogs
           mountPath: /opt/{{include "cv.utils.getOemPath" .}}/k8ssecrets

--- a/charts/hubserver/Chart.yaml
+++ b/charts/hubserver/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: hubserver
 description: A Helm chart for creating the hubserver
 type: application
-version: "1.0.15"
+version: "1.0.16"
 appVersion: "1"

--- a/charts/hubserver/templates/_pvc.tpl
+++ b/charts/hubserver/templates/_pvc.tpl
@@ -169,9 +169,15 @@ storageClass:
           mountPath: /etc/CommVaultRegistry
           subPath: Registry
         {{- end }}
+        {{- if eq (include "cv.installLayoutVersion" . | trim) "v2" }}
         - name: cv-storage-certsandlogs
           mountPath: {{include "cv.paths.appdata" .}}
           subPath: appdata
+        {{- else }}
+        - name: cv-storage-certsandlogs
+          mountPath: {{include "cv.paths.certMountPath" .}}
+          subPath: certificates
+        {{- end }}
         {{- if eq (include "cv.useInitContainer" .) "true" }}
         - name: cv-storage-certsandlogs
           mountPath: /opt/{{include "cv.utils.getOemPath" .}}/k8ssecrets

--- a/charts/mediaagent/Chart.yaml
+++ b/charts/mediaagent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: mediaagent
 description: A Helm chart for creating a media agent
 type: application
-version: "1.0.13"
+version: "1.0.14"
 appVersion: "1"

--- a/charts/mediaagent/templates/_pvc.tpl
+++ b/charts/mediaagent/templates/_pvc.tpl
@@ -169,9 +169,15 @@ storageClass:
           mountPath: /etc/CommVaultRegistry
           subPath: Registry
         {{- end }}
+        {{- if eq (include "cv.installLayoutVersion" . | trim) "v2" }}
         - name: cv-storage-certsandlogs
           mountPath: {{include "cv.paths.appdata" .}}
           subPath: appdata
+        {{- else }}
+        - name: cv-storage-certsandlogs
+          mountPath: {{include "cv.paths.certMountPath" .}}
+          subPath: certificates
+        {{- end }}
         {{- if eq (include "cv.useInitContainer" .) "true" }}
         - name: cv-storage-certsandlogs
           mountPath: /opt/{{include "cv.utils.getOemPath" .}}/k8ssecrets

--- a/charts/networkgateway/Chart.yaml
+++ b/charts/networkgateway/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: networkgateway
 description: A Helm chart for creating an FS agent which can serve as a network gateway
 type: application
-version: "1.0.13"
+version: "1.0.14"
 appVersion: "1"

--- a/charts/networkgateway/templates/_pvc.tpl
+++ b/charts/networkgateway/templates/_pvc.tpl
@@ -169,9 +169,15 @@ storageClass:
           mountPath: /etc/CommVaultRegistry
           subPath: Registry
         {{- end }}
+        {{- if eq (include "cv.installLayoutVersion" . | trim) "v2" }}
         - name: cv-storage-certsandlogs
           mountPath: {{include "cv.paths.appdata" .}}
           subPath: appdata
+        {{- else }}
+        - name: cv-storage-certsandlogs
+          mountPath: {{include "cv.paths.certMountPath" .}}
+          subPath: certificates
+        {{- end }}
         {{- if eq (include "cv.useInitContainer" .) "true" }}
         - name: cv-storage-certsandlogs
           mountPath: /opt/{{include "cv.utils.getOemPath" .}}/k8ssecrets

--- a/charts/webserver/Chart.yaml
+++ b/charts/webserver/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: webserver
 description: A Helm chart for creating the webserver
 type: application
-version: "1.0.15"
+version: "1.0.16"
 appVersion: "1"

--- a/charts/webserver/templates/_pvc.tpl
+++ b/charts/webserver/templates/_pvc.tpl
@@ -169,9 +169,15 @@ storageClass:
           mountPath: /etc/CommVaultRegistry
           subPath: Registry
         {{- end }}
+        {{- if eq (include "cv.installLayoutVersion" . | trim) "v2" }}
         - name: cv-storage-certsandlogs
           mountPath: {{include "cv.paths.appdata" .}}
           subPath: appdata
+        {{- else }}
+        - name: cv-storage-certsandlogs
+          mountPath: {{include "cv.paths.certMountPath" .}}
+          subPath: certificates
+        {{- end }}
         {{- if eq (include "cv.useInitContainer" .) "true" }}
         - name: cv-storage-certsandlogs
           mountPath: /opt/{{include "cv.utils.getOemPath" .}}/k8ssecrets


### PR DESCRIPTION
…yout

- v1 layout (pre-SP42.105): mount subPath:certificates at cv.paths.certMountPath
- v2 layout (SP42.105+): mount subPath:appdata at cv.paths.appdata
- Fixes pods stuck on startup probe after SP42→SP46 upgrade
- Layout detected via commvault.com/install-layout annotation or image version
- Bump chart versions for index update